### PR TITLE
Convert to ES5 syntax

### DIFF
--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -710,7 +710,7 @@ module.exports = function(Chart) {
 			var yTickStart = options.position === 'bottom' ? me.top + axisWidth : me.bottom - tl - axisWidth;
 			var yTickEnd = options.position === 'bottom' ? me.top + axisWidth + tl : me.bottom + axisWidth;
 
-			const displayedTicks = me.ticks.reduce((accum, tick, index) => {
+			var displayedTicks = me.ticks.reduce(function(accum, tick, index) {
 				if (tick) {
 					accum.push({
 						value: tick,
@@ -720,24 +720,24 @@ module.exports = function(Chart) {
 				return accum;
 			}, []);
 
-			let labelOffsets = [];
-			for (let i = 0; i < displayedTicks.length; i++) {
+			var labelOffsets = [];
+			for (i = 0; i < displayedTicks.length; i++) {
 				if (me.ticks.length > (displayedTicks[displayedTicks.length - 1].index + 1)) {
-					let rightTickIndex;
+					var rightTickIndex;
 					if (displayedTicks[i + 1]) {
 						rightTickIndex = displayedTicks[i + 1].index;
 					} else {
 						rightTickIndex = me.ticks.length;
 					}
-					const leftTickIndex = displayedTicks[i].index;
+					var leftTickIndex = displayedTicks[i].index;
 
-					const leftTickLocation = me.getPixelForTick(leftTickIndex);
+					var leftTickLocation = me.getPixelForTick(leftTickIndex);
 
 					// The rightTickIndex corresponds to the first tick of the next month.
 					// We want the last tick of the current month for centering labels.
-					const rightTickLocation = me.getPixelForTick(rightTickIndex - 1);
+					var rightTickLocation = me.getPixelForTick(rightTickIndex - 1);
 
-					const offsetValue = Math.ceil((rightTickLocation - leftTickLocation) / 2);
+					var offsetValue = Math.ceil((rightTickLocation - leftTickLocation) / 2);
 
 					labelOffsets.push({
 						index: displayedTicks[i].index,
@@ -794,10 +794,10 @@ module.exports = function(Chart) {
 					}
 					xLineValue += helpers.aliasPixel(lineWidth);
 
-					let centeringOffset = 0;
+					var centeringOffset = 0;
 
 					if (optionTicks.centerLabels) {
-						labelOffsets.forEach(offset => {
+						labelOffsets.forEach(function(offset) {
 							if (offset.index === index) {
 								centeringOffset = offset.value;
 							}


### PR DESCRIPTION
Uglify breaks on this code when it is in syntax later than ES5. 

It doesn't go into the babel loader because it ends up in `node_modules`.